### PR TITLE
Fix product update assignment

### DIFF
--- a/backend/src/src/services/productService.js
+++ b/backend/src/src/services/productService.js
@@ -51,8 +51,8 @@ export const createProductsService = async(productsData) => {
 export const updateProductService = async (id, productData) => {
     const product = await findProductById(id);
 
-    const newProduct = await Product.assign(product, productData);
-    await newProduct.save();
+    Object.assign(product, productData);
+    await product.save();
 
     return { message: "Product updated successfully" };
 }


### PR DESCRIPTION
## Summary
- replace the unsupported Product.assign usage with Object.assign before saving the updated product document
- ensure the product document itself is persisted via await product.save()

## Testing
- node - <<'NODE' (manual verification of Object.assign update flow)


------
https://chatgpt.com/codex/tasks/task_e_68d5d23b8e2c832fb8a9bc4b442f9f6e