### PR TITLE
Implement dynamic color inputs in create product form

### DIFF
--- a/src/components/CreateProduct.tsx
+++ b/src/components/CreateProduct.tsx
@@ -1,5 +1,10 @@
 import React from "react";
-import type { Category, Product, ProductSpecs } from "../types/types";
+import type {
+  Category,
+  Product,
+  ProductColor,
+  ProductSpecs,
+} from "../types/types";
 import CreateCategory from "./CreateCategory";
 import CreateProductForm from "./CreateProductForm";
 import "../styles/CreateProduct.css";
@@ -18,6 +23,12 @@ interface CreateProductProps {
   onChangeSpecs: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onSizesChange: (value: string[]) => void;
   onChangeImageFile: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onAddColor: () => void;
+  onChangeColor: (
+    index: number,
+    field: keyof ProductColor,
+    value: string | number
+  ) => void;
 
   onCreateProduct: (
     e: React.FormEvent<HTMLFormElement>
@@ -39,6 +50,8 @@ const CreateProduct: React.FC<CreateProductProps> = ({
   onChangeSpecs,
   onSizesChange,
   onChangeImageFile,
+  onAddColor,
+  onChangeColor,
   onCreateProduct,
   onCreateCategory,
   loadingCreateProduct,
@@ -47,24 +60,26 @@ const CreateProduct: React.FC<CreateProductProps> = ({
   return (
     <main className="create-main">
       <section className="create-section">
-        <CreateCategory 
-            onCreateCategory={onCreateCategory}
-            onChangeCategory={onChangeCategory}
-            category={category}
-            loadingCreateCategory={loadingCreateCategory}
+        <CreateCategory
+          onCreateCategory={onCreateCategory}
+          onChangeCategory={onChangeCategory}
+          category={category}
+          loadingCreateCategory={loadingCreateCategory}
         />
       </section>
 
       <section className="create-section-spaced">
         <CreateProductForm
-            onCreateProduct={onCreateProduct}
-            onChangeProduct={onChangeProduct}
-            onChangeSpecs={onChangeSpecs}
-            onSizesChange={onSizesChange}
-            onChangeImageFile={onChangeImageFile}
-            product={product}
-            especificaciones={especificaciones}
-            loadingCreateProduct={loadingCreateProduct}
+          onCreateProduct={onCreateProduct}
+          onChangeProduct={onChangeProduct}
+          onChangeSpecs={onChangeSpecs}
+          onSizesChange={onSizesChange}
+          onChangeImageFile={onChangeImageFile}
+          onAddColor={onAddColor}
+          onChangeColor={onChangeColor}
+          product={product}
+          especificaciones={especificaciones}
+          loadingCreateProduct={loadingCreateProduct}
         />
       </section>
     </main>

--- a/src/components/CreateProductForm.tsx
+++ b/src/components/CreateProductForm.tsx
@@ -1,4 +1,4 @@
-import type { Product, ProductSpecs } from "../types/types";
+import type { Product, ProductColor, ProductSpecs } from "../types/types";
 
 interface CreateProductFormProps {
   onCreateProduct: (
@@ -10,6 +10,12 @@ interface CreateProductFormProps {
   onChangeSpecs: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onSizesChange: (value: string[]) => void;
   onChangeImageFile: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onAddColor: () => void;
+  onChangeColor: (
+    index: number,
+    field: keyof ProductColor,
+    value: string | number
+  ) => void;
   product: Product;
   especificaciones: ProductSpecs;
   loadingCreateProduct?: boolean;
@@ -21,12 +27,15 @@ const CreateProductForm: React.FC<CreateProductFormProps> = ({
   onChangeSpecs,
   onSizesChange,
   onChangeImageFile,
+  onAddColor,
+  onChangeColor,
   product,
   especificaciones,
   loadingCreateProduct,
 }) => {
 
-    const sizesOptions = ["XS", "S", "M", "L", "XL", "XXL"];
+  const sizesOptions = ["XS", "S", "M", "L", "XL", "XXL"];
+  const colors = Array.isArray(product.colores) ? product.colores : [];
   return (
     <>
       <h2>Crear producto</h2>
@@ -92,15 +101,57 @@ const CreateProductForm: React.FC<CreateProductFormProps> = ({
           readOnly
         />
 
-        <label htmlFor="prod_color">Colores</label>
-        <input 
-          id="prod_color"
-          name="colores"
-          type="text"
-          value={(product.colores || []).map((c: any) => c.name ?? c).join(", ")}
-          onChange={onChangeProduct}
-          placeholder="Colores del producto separados por comas"
-        />
+        <label>Colores</label>
+        <div className="color-rows">
+          {colors.length === 0 && (
+            <button
+              type="button"
+              className="color-add"
+              onClick={onAddColor}
+              aria-label="Agregar color"
+            >
+              +
+            </button>
+          )}
+          {colors.map((color, index) => (
+            <div className="color-row" key={`color-${index}`}>
+              <input
+                type="text"
+                value={color.name ?? ""}
+                onChange={(e) => onChangeColor(index, "name", e.target.value)}
+                placeholder="Nombre"
+              />
+              <input
+                type="number"
+                min={0}
+                value={color.cantidad ?? 0}
+                onChange={(e) =>
+                  onChangeColor(index, "cantidad", Number(e.target.value) || 0)
+                }
+                placeholder="Cantidad"
+              />
+              <input
+                type="number"
+                min={0}
+                value={color.stock ?? 0}
+                onChange={(e) =>
+                  onChangeColor(index, "stock", Number(e.target.value) || 0)
+                }
+                placeholder="Stock"
+              />
+              {index === colors.length - 1 && (
+                <button
+                  type="button"
+                  className="color-add"
+                  onClick={onAddColor}
+                  aria-label="Agregar color"
+                >
+                  +
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
 
         <label htmlFor="prod_pactual">Precio actual</label>
         <input
@@ -129,16 +180,6 @@ const CreateProductForm: React.FC<CreateProductFormProps> = ({
           type="number"
           step="1"
           value={product.descuento}
-          onChange={onChangeProduct}
-        />
-
-        <label htmlFor="prod_stock">Stock</label>
-        <input
-          id="prod_stock"
-          name="stock"
-          type="number"
-          step="1"
-          value={product.stock}
           onChange={onChangeProduct}
         />
 

--- a/src/styles/CreateProduct.css
+++ b/src/styles/CreateProduct.css
@@ -84,3 +84,39 @@
   padding: 0.35rem 0.6rem;
 }
 
+.color-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.color-row {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr)) auto;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.color-row input {
+  width: 100%;
+}
+
+.color-add {
+  padding: 0.55rem;
+  border: 1px solid #2563eb;
+  background-color: #2563eb;
+  color: #fff;
+  border-radius: 8px;
+  font-size: 1.1rem;
+  line-height: 1;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.color-add:hover {
+  background-color: #1d4ed8;
+  border-color: #1d4ed8;
+}
+


### PR DESCRIPTION
## Summary
- add dynamic color rows with name, quantity, and stock inputs to the create product form
- remove the manual stock input and compute product stock from the sum of color stocks
- update product creation logic to manage color entries and apply styling for the new layout

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68f3ee954efc832fb14472975ce495b9